### PR TITLE
Increase line-height to prevent scrollbars when using 'Scheherazade New'

### DIFF
--- a/site/assets/_custom.scss
+++ b/site/assets/_custom.scss
@@ -75,6 +75,10 @@ body {
     direction: rtl;
 }
 
+.verse-container .arabic {
+    line-height: 1.8;
+}
+
 .transliteration,
 .transliteration-phrase-by-phrase {
     direction: ltr;


### PR DESCRIPTION
I've only seen this on mobile, but not using  the table based 'phrase-by-phrase' translations scrollbars seem to appear 