### PR TITLE
Implement persistent chorus

### DIFF
--- a/site/assets/_custom.scss
+++ b/site/assets/_custom.scss
@@ -79,6 +79,62 @@ body {
     line-height: 1.8;
 }
 
+.sticky-chorus {
+    top: 30px;
+    z-index: 90;
+    background-color: rgba(255, 255, 255, 0.9);
+    transition: transform 0.3s ease-in-out;
+}
+
+#chorus-toggle {
+    display: none;
+
+    &:not(:checked) {
+        &~label[for="chorus-toggle"] {
+            color: pink;
+        }
+    }
+
+    &:not(:checked)~.sticky-chorus {
+        position: sticky;
+        // position: fixed->sticky is not a transition, this animation helps make less jarring
+        animation: slideIn 0.4s ease-out forwards;
+        max-height: 70vh;
+        overflow-y: scroll;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+    }
+}
+
+@keyframes slideIn {
+    from {
+        transform: translateY(-50px); // Start slightly above
+        opacity: 0.8; // Slight transparency
+    }
+
+    to {
+        transform: translateY(0); // Settle into position
+        opacity: 1; // Fully visible
+    }
+}
+
+
+label[for="chorus-toggle"] {
+
+    position: sticky;
+    top: 35px;
+    z-index: 95;
+    background-color: rgb(0, 0, 0);
+    transition: transform 0.3s ease-in-out;
+    transform: translateX(-10px);
+
+    padding: 5px;
+    border-radius: 5px 15px 15px 5px;
+
+    color: white;
+    writing-mode: sideways-rl;
+
+}
+
 .transliteration,
 .transliteration-phrase-by-phrase {
     direction: ltr;

--- a/site/layouts/shortcodes/verse.html
+++ b/site/layouts/shortcodes/verse.html
@@ -33,7 +33,7 @@ e.g. verse thalama en
     {{ range $v_config_idx, $v_config := $verses_json.order.chorus }}
     <div class="verse-container">
 
-        {{ $verse_num = (delimit (slice "## Chorus " $v_config_idx) "") }}
+        {{ $verse_num = (delimit (slice "## Chorus " (add $v_config_idx 1)) "") }}
 
         {{ $json_string := jsonify (dict
         "verse_num" $verse_num
@@ -50,7 +50,7 @@ e.g. verse thalama en
 {{ end }}
 
 {{ range $v_config_idx, $v_config := $verses_json.order.verses }}
-{{ $verse_num = (delimit (slice "## " $v_config_idx) "") }}
+{{ $verse_num = (delimit (slice "## " (add $v_config_idx 1)) "") }}
 <div class="verse-container">
     {{ $json_string := jsonify (dict
     "verse_num" $verse_num

--- a/site/layouts/shortcodes/verse.html
+++ b/site/layouts/shortcodes/verse.html
@@ -8,6 +8,7 @@ e.g. verse thalama en
 
 */}}
 
+
 {{ $verse_file_name := .Get "file" }}
 {{ $verse_lang := .Get "lang" }}
 
@@ -15,70 +16,99 @@ e.g. verse thalama en
 {{- $verse_filepath_parts := split $verse_file_name "/" -}}
 {{- $verses_json := .Site.Data -}}
 {{- range $index, $part := $verse_filepath_parts -}}
-    {{- $verses_json = index $verses_json $part -}}
+{{- $verses_json = index $verses_json $part -}}
 {{- end -}}
 
 {{/* Access the verses for the language provided */}}
 {{ $verses_in_lang := (index (index $verses_json "verses") $verse_lang) }}
 {{ $verses_in_lang_translated := (index (index $verses_json "translation") $verse_lang) }}
 
-{{ $how_many_chorus := (len $verses_json.order.chorus) }}
-
-{{ $verses_to_display := $verses_json.order.chorus | append $verses_json.order.verses}}
-{{ $total_verses := (len $verses_to_display) }}
-
 {{ $verse_num := "??" }}
 
-{{/* {{ range $v_idx, $v_ara := $verses_json.verses.ara }} */}}
-{{ range $v_config_idx, $v_config := $verses_to_display }}
+{{ if (gt (len $verses_json.order.chorus) 0) }}
+<input type="checkbox" id="chorus-toggle">
+<label for="chorus-toggle">Chorus</label>
+
+<div class="sticky-chorus">
+    {{ range $v_config_idx, $v_config := $verses_json.order.chorus }}
+    <div class="verse-container">
+
+        {{ $verse_num = (delimit (slice "## Chorus " $v_config_idx) "") }}
+
+        {{ $json_string := jsonify (dict
+        "verse_num" $verse_num
+        "v_config" $v_config
+        "verses_json" $verses_json
+        "verses_in_lang" $verses_in_lang
+        "verses_in_lang_translated" $verses_in_lang_translated)
+        }}
+
+        {{ template "inline/partials/verse_renderer" (dict "params_json" $json_string) }}
+    </div>
+    {{ end }}
+</div>
+{{ end }}
+
+{{ range $v_config_idx, $v_config := $verses_json.order.verses }}
+{{ $verse_num = (delimit (slice "## " $v_config_idx) "") }}
 <div class="verse-container">
+    {{ $json_string := jsonify (dict
+    "verse_num" $verse_num
+    "v_config" $v_config
+    "verses_json" $verses_json
+    "verses_in_lang" $verses_in_lang
+    "verses_in_lang_translated" $verses_in_lang_translated)
+    }}
 
-    {{ if (gt $how_many_chorus 0) }}
-    {{ $verse_num = (delimit (slice "## Chorus " $v_config_idx) "") }}
-    {{ $total_verses = sub $total_verses 1 }}
-    {{ $how_many_chorus = sub $how_many_chorus 1 }}
-    {{ else }}
-    {{ $verse_num = (delimit (slice "## " $v_config_idx) "") }}
+    {{ template "inline/partials/verse_renderer" (dict "params_json" $json_string) }}
+</div>
+{{ end }}
+
+
+{{ define "inline/partials/verse_renderer" }}
+{{ $params_obj := unmarshal .params_json }}
+{{ $verse_num := index $params_obj "verse_num" }}
+{{ $v_config := index $params_obj "v_config" }}
+{{ $verses_json := index $params_obj "verses_json" }}
+{{ $verses_in_lang := index $params_obj "verses_in_lang" }}
+{{ $verses_in_lang_translated := index $params_obj "verses_in_lang_translated" }}
+
+{{ $verse_num | markdownify }}
+<p style="flex-basis: 100%; margin: 0;"></p>
+
+{{ range $new_verse := $v_config }}
+{{ $v_idx := int (index $new_verse "index") }}
+{{ $v_ara := index $verses_json.verses.ara $v_idx }}
+
+{{ $v_in_lang := index $verses_in_lang $v_idx }}
+{{ $v_in_lang_translated := index $verses_in_lang_translated $v_idx }}
+{{ range $w_idx, $word_ara := $v_ara }}
+<table class="verse">
+    <tbody>
+        <tr class="arabic">
+            <td>{{ $word_ara }}</td>
+        </tr>
+        <tr class="transliteration-phrase-by-phrase">
+            <td>{{index $v_in_lang $w_idx }}</td>
+        </tr>
+        <tr class="translation-phrase-by-phrase">
+            <td>{{index $v_in_lang_translated $w_idx | markdownify }}</td>
+        </tr>
+    </tbody>
+</table>
+{{ end }}
+<div class="transliteration" style="flex-basis: 100%; text-align: right;">
+    {{ with $v_in_lang }}
+    {{ delimit $v_in_lang " " }}
     {{ end }}
-
-    {{ $verse_num | markdownify }}
-    <p style="flex-basis: 100%; margin: 0;"></p>
-    {{/* {{ $verse_num.RenderString }} */}}
-
-    {{ range $new_verse := $v_config }}
-    {{ $v_idx := int (index $new_verse "index") }}
-    {{ $v_ara := index $verses_json.verses.ara $v_idx }}
-
-    {{ $v_in_lang := index $verses_in_lang $v_idx }}
-    {{ $v_in_lang_translated := index $verses_in_lang_translated $v_idx }}
-    {{ range $w_idx, $word_ara := $v_ara }}
-    <table class="verse">
-        <tbody>
-            <tr class="arabic">
-                <td>{{ $word_ara }}</td>
-            </tr>
-            <tr class="transliteration-phrase-by-phrase">
-                <td>{{index $v_in_lang $w_idx }}</td>
-            </tr>
-            <tr class="translation-phrase-by-phrase">
-                <td>{{index $v_in_lang_translated $w_idx | markdownify }}</td>
-            </tr>
-        </tbody>
-    </table>
+</div>
+<div class="translation" style="flex-basis: 100%; text-align: right;">
+    {{ with $v_in_lang }}
+    {{ (delimit $v_in_lang_translated " ") | markdownify }}
     {{ end }}
-    <div class="transliteration" style="flex-basis: 100%; text-align: right;">
-        {{ with $v_in_lang }}
-            {{ delimit $v_in_lang " " }}
-        {{ end }}
-    </div>
-    <div class="translation" style="flex-basis: 100%; text-align: right;">
-        {{ with $v_in_lang }}
-            {{ (delimit $v_in_lang_translated " ") | markdownify }}
-        {{ end }}
-    </div>
-    {{ end }}
-    <div style="flex-basis: 100%;">
-        {{ "------" | markdownify }}
-    </div>
+</div>
+{{ end }}
+<div style="flex-basis: 100%;">
+    {{ "------" | markdownify }}
 </div>
 {{ end }}


### PR DESCRIPTION
Making a pure CSS solution for persistent chorus, after motivation from #28 

## Change Summary
1. Add a toggle for showing the chorus during reading
2. (finally) correct the numbering to start from 1 not 0 for both Chorus and Verse
3. (dev-only) updated the `verse` shortcode to be less logically complicated, needing to use a workaraound in hugo to pass in a nested JSON by stringifying it. Really surprised that nested dicts cannot be passed as a param, and that it doesn't throw a warning, just returns nil ...